### PR TITLE
Added shields for navigating other versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Umbraco! [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/main/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Awesome Umbraco! [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/main/media/badge.svg)](https://github.com/sindresorhus/awesome) [![UmbracoV9](https://img.shields.io/badge/Umbraco-v9-blue)](https://our.umbraco.com/download/releases/900)
 
 > A collection of awesome [Umbraco CMS](https://github.com/umbraco/Umbraco-CMS/) packages, resources and shiny things.
 
@@ -12,9 +12,13 @@ Please read the [contribution guidelines and quality standard](https://github.co
 
 Thank you to all [contributors](https://github.com/umbraco-community/awesome-umbraco/graphs/contributors), you are awesome and this list wouldn't be possible without you! The goal is to build a categorized community-driven collection of very well-known resources.
 
-### Contents
-This list is for Umbraco v9, if you looking for v8, you can find those [here](UMBRACO-V8.md).
+### Versions
+This list is for Umbraco v9 packages. However, we also have lists for older versions! Check them out too.
 
+[![UmbracoV8](https://img.shields.io/badge/Umbraco-v8-blue)](UMBRACO-V8.md)
+[![UmbracoV7](https://img.shields.io/badge/Umbraco-v7-blue)](UMBRACO-V7.md)
+
+### Contents
 * [Official](#official)
 * [Community](#community)
 * [Backoffice extensions](#backoffice-extensions)

--- a/UMBRACO-V7.md
+++ b/UMBRACO-V7.md
@@ -13,7 +13,7 @@ Please read the [contribution guidelines and quality standard](https://github.co
 Thank you to all [contributors](https://github.com/umbraco-community/awesome-umbraco/graphs/contributors), you are awesome and this list wouldn't be possible without you! The goal is to build a categorized community-driven collection of very well-known resources.
 
 ### Versions
-This list is for Umbraco v8 packages. However, we also have lists for other versions! Check them out too.
+This list is for Umbraco v7 packages. However, we also have lists for other versions! Check them out too.
 
 [![UmbracoV9](https://img.shields.io/badge/Umbraco-v9-blue)](UMBRACO-V9.md)
 [![UmbracoV8](https://img.shields.io/badge/Umbraco-v8-blue)](UMBRACO-V8.md)

--- a/UMBRACO-V7.md
+++ b/UMBRACO-V7.md
@@ -1,4 +1,4 @@
-# Awesome Umbraco! [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/main/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Awesome Umbraco! [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/main/media/badge.svg)](https://github.com/sindresorhus/awesome) [![UmbracoV7](https://img.shields.io/badge/Umbraco-v7-blue)](https://our.umbraco.com/download/releases/700)
 
 > A collection of awesome [Umbraco CMS](https://github.com/umbraco/Umbraco-CMS/) packages, resources and shiny things.
 
@@ -11,6 +11,12 @@ Inspired by [awesome lists](https://github.com/sindresorhus/awesome). For genera
 Please read the [contribution guidelines and quality standard](https://github.com/umbraco-community/awesome-umbraco/blob/master/CONTRIBUTING.md) page before making a pull-request. If you see a resource or package here that is no longer maintained, please submit a pull request to help improve this collection.
 
 Thank you to all [contributors](https://github.com/umbraco-community/awesome-umbraco/graphs/contributors), you are awesome and this list wouldn't be possible without you! The goal is to build a categorized community-driven collection of very well-known resources.
+
+### Versions
+This list is for Umbraco v8 packages. However, we also have lists for other versions! Check them out too.
+
+[![UmbracoV9](https://img.shields.io/badge/Umbraco-v9-blue)](UMBRACO-V9.md)
+[![UmbracoV8](https://img.shields.io/badge/Umbraco-v8-blue)](UMBRACO-V8.md)
 
 ### Contents
 

--- a/UMBRACO-V8.md
+++ b/UMBRACO-V8.md
@@ -1,4 +1,4 @@
-# Awesome Umbraco! [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/main/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Awesome Umbraco! [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/main/media/badge.svg)](https://github.com/sindresorhus/awesome) [![UmbracoV8](https://img.shields.io/badge/Umbraco-v8-blue)](https://our.umbraco.com/download/releases/800)
 
 > A collection of awesome [Umbraco CMS](https://github.com/umbraco/Umbraco-CMS/) packages, resources and shiny things.
 
@@ -12,9 +12,13 @@ Please read the [contribution guidelines and quality standard](https://github.co
 
 Thank you to all [contributors](https://github.com/umbraco-community/awesome-umbraco/graphs/contributors), you are awesome and this list wouldn't be possible without you! The goal is to build a categorized community-driven collection of very well-known resources.
 
-### Contents
-This list is for Umbraco v8, if you looking for v7, you can find those [here](UMBRACO-V7.md).
+### Versions
+This list is for Umbraco v8 packages. However, we also have lists for other versions! Check them out too.
 
+[![UmbracoV9](https://img.shields.io/badge/Umbraco-v9-blue)](UMBRACO-V9.md)
+[![UmbracoV7](https://img.shields.io/badge/Umbraco-v7-blue)](UMBRACO-V7.md)
+
+### Contents
 * [Official](#official)
 * [Community](#community)
 * [Backoffice extensions](#backoffice-extensions)


### PR DESCRIPTION
Was thinking of improving the navigation between versions a bit and thought that shields would be a nice way of doing it:
![image](https://user-images.githubusercontent.com/11466511/167471516-17609952-9080-4ad3-8cbc-c9e419eebe14.png)
